### PR TITLE
fix: use assignment syntax for repo URLs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,8 @@ repositories {
 		name = "Terraformers"
 		url = "https://maven.terraformersmc.com/"
 	}
-	maven { url "https://maven.shedaniel.me/" }
-	maven { url "https://maven.terraformersmc.com/releases/" }
+	maven { url = "https://maven.shedaniel.me/" }
+	maven { url = "https://maven.terraformersmc.com/releases/" }
 
 	// Other repositories can go above or below Modrinth's. We don't need priority :)
 	exclusiveContent {


### PR DESCRIPTION
## Summary
- update Shedaniel and Terraformers repo definitions to use `url =` syntax

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686b4bd9cf0c832e8180f0f856651411